### PR TITLE
Fix touch events in touch bar

### DIFF
--- a/touchbar_nyancat/NyanCatCanvas.swift
+++ b/touchbar_nyancat/NyanCatCanvas.swift
@@ -13,7 +13,7 @@ class NyanCatCanvas: NSView {
     var imageLoaded: Bool = false
     
     static let MAX_POSITION: CGFloat = 0
-    static let MIN_POSITION: CGFloat = -680
+    static let MIN_POSITION: CGFloat = -646
     
     var xPosition: CGFloat = MIN_POSITION {
         didSet {

--- a/touchbar_nyancat/NyanCatCanvas.swift
+++ b/touchbar_nyancat/NyanCatCanvas.swift
@@ -12,8 +12,9 @@ class NyanCatCanvas: NSView {
     var timer: Timer?
     var imageLoaded: Bool = false
     
+    static let SPRITE_SIZE: CGFloat = 34
     static let MAX_POSITION: CGFloat = 0
-    static let MIN_POSITION: CGFloat = -646
+    static let MIN_POSITION: CGFloat = -680 + SPRITE_SIZE
     
     var xPosition: CGFloat = MIN_POSITION {
         didSet {
@@ -21,6 +22,7 @@ class NyanCatCanvas: NSView {
         }
     }
     var direction: CGFloat = 1
+    var touching: Bool = false
     let imageUrl = "https://i.imgur.com/7pgdK28.gif"
 
     var backgroundImageView: NSImageView = {
@@ -59,10 +61,22 @@ class NyanCatCanvas: NSView {
     }
 
     override func touchesBegan(with event: NSEvent) {
-        timer?.invalidate()
+        if #available(macOS 10.12.2, *) {
+            if let touch = event.allTouches().first {
+                let current = touch.location(in: self).x
+                if xPosition - current < NyanCatCanvas.MIN_POSITION && xPosition - current > NyanCatCanvas.MIN_POSITION - NyanCatCanvas.SPRITE_SIZE - 8 { // Accounts for whitespace
+                    touching = true
+                    timer?.invalidate()
+                }
+            }
+        }
     }
     
     override func touchesMoved(with event: NSEvent) {
+        if !touching {
+            return
+        }
+        
         if #available(macOS 10.12.2, *) {
             if let touch = event.allTouches().first {
                 let current = touch.location(in: self).x
@@ -75,6 +89,11 @@ class NyanCatCanvas: NSView {
     }
     
     override func touchesEnded(with event: NSEvent) {
+        if !touching {
+            return
+        }
+        
+        touching = false
         timer?.invalidate()
         timer = Timer.scheduledTimer(timeInterval: 0.01, target: self, selector: #selector(moveNyancat), userInfo: nil, repeats: true)
     }

--- a/touchbar_nyancat/NyanCatCanvas.swift
+++ b/touchbar_nyancat/NyanCatCanvas.swift
@@ -11,7 +11,11 @@ import Cocoa
 class NyanCatCanvas: NSView {
     var timer: Timer?
     var imageLoaded: Bool = false
-    var xPosition: CGFloat = -680 {
+    
+    static let MAX_POSITION: CGFloat = 0
+    static let MIN_POSITION: CGFloat = -680
+    
+    var xPosition: CGFloat = MIN_POSITION {
         didSet {
             setFrame()
         }
@@ -44,7 +48,7 @@ class NyanCatCanvas: NSView {
     }
 
     func setupSize() {
-        xPosition = -680
+        xPosition = NyanCatCanvas.MIN_POSITION
         setFrame()
     }
 
@@ -64,7 +68,8 @@ class NyanCatCanvas: NSView {
                 let current = touch.location(in: self).x
                 let previous = touch.previousLocation(in: self).x
                 let dX = current - previous
-                xPosition += dX
+                
+                xPosition = max(min(xPosition + dX, NyanCatCanvas.MAX_POSITION), NyanCatCanvas.MIN_POSITION)
             }
         }
     }
@@ -76,8 +81,8 @@ class NyanCatCanvas: NSView {
     
     @objc func moveNyancat() {
         xPosition += direction
-        if xPosition > 0 { direction = -1 }
-        else if xPosition < -680 { direction = 1 }
+        if xPosition > NyanCatCanvas.MAX_POSITION { direction = -1 }
+        else if xPosition < NyanCatCanvas.MIN_POSITION { direction = 1 }
     }
 
     func downloadImage() {


### PR DESCRIPTION
Due to a breaking software change, the touch bar view no longer responds to touch events. This PR does the following:

- Fixes the touch events not being handled
- Prevents touch events from moving the image out of the view of the touch bar
- Restricts movement of the image to when the touch event is occurring on the Nyan Cat sprite itself
- Refactors code